### PR TITLE
Kjc assign owner

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -10,7 +10,7 @@ import "./AnimalCard.css"
 import { fetchIt } from "../../repositories/Fetch";
 
 
-export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) => {
+export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners, animalOwners }) => {
     const currentTime = new Date()
     const history = useHistory()
 
@@ -63,8 +63,8 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) =>
 
     useEffect(() => {
         animalId = currentAnimal.id
-        currentAnimal = {}
-        resolveResource(currentAnimal, animalId, AnimalRepository.get)
+        let resetAnimal = {}
+        resolveResource(resetAnimal, animalId, AnimalRepository.get)
     }, [treatment])
 
     //sets state for allOwners whenever owners is passed an a argument for the Animal function
@@ -79,11 +79,11 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) =>
         return AnimalOwnerRepository
             .getOwnersByAnimal(currentAnimal.id)
             .then(people => setPeople(people))
-    }
-
-    //invokes getPeople when currentAnimal changes
-    useEffect(() => {
-        getPeople()
+        }
+        
+        //invokes getPeople when currentAnimal changes
+        useEffect(() => {
+            getPeople()
     }, [currentAnimal])
 
     //listens to animalId to change and excutes code
@@ -92,7 +92,7 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) =>
             defineClasses("card animal--single")
             setDetailsOpen(true)
             //fetches expanded animalUsers by animalId
-            AnimalOwnerRepository.getOwnersByAnimal(animalId)
+             AnimalOwnerRepository.getOwnersByAnimal(animalId)
                 .then(d => setPeople(d))
                 .then(() => {
                     //sets state of allOwners to all users that have an employee property of false
@@ -153,7 +153,7 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) =>
 
 
                             {
-                                isEmployee && myOwners.length < 2
+                                isEmployee && currentAnimal.animalOwners.length < 2
                                     ? <select value={owner}
                                         name="owner"
                                         className="form-control small"
@@ -161,7 +161,7 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) =>
                                             selectOwner(parseInt(evt.target.value))
                                         }} >
                                         <option value="">
-                                            Select {myOwners.length === 1 ? "another" : "an"} owner
+                                            Select {currentAnimal.animalOwners.length === 1 ? "another" : "an"} owner
                                         </option>
                                         {
                                             allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)
@@ -171,7 +171,7 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners }) =>
                             }
 
                             {
-                                isEmployee && myOwners.length < 2
+                                isEmployee && currentAnimal.animalOwners.length < 2
                                     ? <button className="btn btn-warning mt-3 form-control small" onClick={handleOwner}>Assign Owner</button>
                                     : ""
                             }

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -48,8 +48,11 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners, anim
     }
 
     const handleOwner = (event) => {
+        animalId = currentAnimal.id
+        let resetAnimal = {}
         event.preventDefault()
         return AnimalOwnerRepository.assignOwner(currentAnimal.id, owner)
+        .then(resolveResource(resetAnimal, animalId, AnimalRepository.get))
             .then(selectOwner(0))
     }
 
@@ -149,7 +152,7 @@ export const Animal = ({ animal, syncAnimals, showTreatmentHistory, owners, anim
                             <h6>Owners</h6>
                             <span className="small">
                                 {
-                                    myOwners.map(owner => <div key={`owner--${owner.id}`}>{owner.user.name}</div>)
+                                    currentAnimal.animalOwners?.map(owner => <div key={`owner--${owner.id}`}>{owner.user.name}</div>)
                                 }
                             </span>
 


### PR DESCRIPTION
# Description

Added the ability for only employees to assign owners to each animal. It then updates the list of owners and if an animal already has 2 owners you can no longer assign owners

Fixes #12 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Sign in as a customer 
- [x] Check to see if you click on one of your animals, and you should not be able to see the assign owner dropdown or button
- [x] Log back out
- [x] Sign in as an employee
- [x] Check to see that when you click on an animal that you see the assign owner dropdown and button
- [x] If an animal has no owners the dropdown should say select "an" owner, and if they have one owner, the dropdown should say select "another" owner
- [x] When you select an owner and click the Assign Owner button, you should immediately see the owner show above
- [x] If you add an owner and it's the second owner, in addition to the owner list being updated, the owner dropdown and button should no longer be visible

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
